### PR TITLE
Integration method

### DIFF
--- a/src/main/java/org/neuroml/export/neuron/NeuronWriter.java
+++ b/src/main/java/org/neuroml/export/neuron/NeuronWriter.java
@@ -2555,7 +2555,6 @@ public class NeuronWriter extends ANeuroMLBaseWriter
             StringBuilder ratesMethod, HashMap<String, HashMap<String, String>> paramMappings, String ionSpecies) throws ContentError
     {
 
-        StringBuilder ratesMethodFinal = new StringBuilder();
 
         if(comp.getComponentType().hasDynamics())
         {
@@ -2569,9 +2568,6 @@ public class NeuronWriter extends ANeuroMLBaseWriter
 
                 blockAssigned.append(rateName + " " + rateUnits + "\n");
 
-                // ratesMethod.append(rateName + " = " +
-                // NRNUtils.checkForStateVarsAndNested(td.getEvaluable().toString(),
-                // comp, paramMappings) + " ? \n");
                 String rateExpr = NRNUtils.checkForStateVarsAndNested(td.getValueExpression(), comp, paramMappings);
                 rateNameVsRateExpr.put(rateName, rateExpr);
 
@@ -2580,7 +2576,7 @@ public class NeuronWriter extends ANeuroMLBaseWriter
 
                     String stateVarToUse = NRNUtils.getStateVarName(td.getStateVariable().getName());
 
-                    String line = prefix + stateVarToUse + "' = " + rateName;
+                    String line = prefix + stateVarToUse + "' = " + rateNameVsRateExpr.get(rateName);
 
                     if(comp.getComponentType().isOrExtends(NeuroMLElements.CONC_MODEL_COMP_TYPE) &&
                         td.getStateVariable().getName().equals(NeuroMLElements.CONC_MODEL_CONC_STATE_VAR))
@@ -2595,7 +2591,7 @@ public class NeuronWriter extends ANeuroMLBaseWriter
                 }
                 else
                 {
-                    ratesMethodFinal.append(prefix + NRNUtils.getStateVarName(td.getStateVariable().getName()) + " = -1 * " + rateName + "\n");
+                    ratesMethod.append(prefix + NRNUtils.getStateVarName(td.getStateVariable().getName()) + " = -1 * " + rateName + "\n");
                 }
 
             }
@@ -2655,7 +2651,7 @@ public class NeuronWriter extends ANeuroMLBaseWriter
 
                     if(!td.getStateVariable().getName().equals(NRNUtils.NEURON_VOLTAGE))
                     {
-                        String line = prefix + NRNUtils.getStateVarName(td.getStateVariable().getName()) + "' = " + rateName;
+                        String line = prefix + NRNUtils.getStateVarName(td.getStateVariable().getName()) + "' = " + rateNameVsRateExpr.get(rateName);
 
                         if(!blockDerivative.toString().contains(line))
                         {
@@ -2664,20 +2660,10 @@ public class NeuronWriter extends ANeuroMLBaseWriter
                     }
                     else
                     {
-                        ratesMethodFinal.append(prefix + NRNUtils.getStateVarName(td.getStateVariable().getName()) + " = -1 * " + rateName + "\n"); // //
+                        ratesMethod.append(prefix + NRNUtils.getStateVarName(td.getStateVariable().getName()) + " = -1 * " + rateName + "\n");
                     }
                 }
             }
-
-            for(String rateName : rateNameVsRateExpr.keySet())
-            {
-                String rateExpr = rateNameVsRateExpr.get(rateName);
-
-                ratesMethod.append(rateName + " = " + rateExpr + " ? Note units of all quantities used here need to be consistent!\n");
-
-            }
-
-            ratesMethod.append("\n" + ratesMethodFinal + " \n");
 
         }
 

--- a/src/main/java/org/neuroml/export/neuron/NeuronWriter.java
+++ b/src/main/java/org/neuroml/export/neuron/NeuronWriter.java
@@ -1833,7 +1833,7 @@ public class NeuronWriter extends ANeuroMLBaseWriter
         {
             //TODO: nasty numerics in neuron: https://www.neuron.yale.edu/phpBB/viewtopic.php?f=28&t=592
             //      this is a disgusting workaround
-            String method = blockNeuron.indexOf("READ cai, cao") > 0 ?  "cnexp" : "derivimplicit";
+            String method = hasCaDependency ?  "derivimplicit" : "cnexp";
             blockBreakpoint.insert(0, String.format("SOLVE states METHOD %s\n\n", method));
         }
 

--- a/src/main/java/org/neuroml/export/neuron/NeuronWriter.java
+++ b/src/main/java/org/neuroml/export/neuron/NeuronWriter.java
@@ -1831,7 +1831,10 @@ public class NeuronWriter extends ANeuroMLBaseWriter
 
         if(blockDerivative.length() > 0)
         {
-            blockBreakpoint.insert(0, "SOLVE states METHOD cnexp\n\n");
+            //TODO: nasty numerics in neuron: https://www.neuron.yale.edu/phpBB/viewtopic.php?f=28&t=592
+            //      this is a disgusting workaround
+            String method = blockNeuron.indexOf("READ cai, cao") > 0 ?  "cnexp" : "derivimplicit";
+            blockBreakpoint.insert(0, String.format("SOLVE states METHOD %s\n\n", method));
         }
 
         if(comp.getComponentType().isOrExtends(NeuroMLElements.ION_CHANNEL_KS_COMP_TYPE))

--- a/src/main/java/org/neuroml/export/neuron/NeuronWriter.java
+++ b/src/main/java/org/neuroml/export/neuron/NeuronWriter.java
@@ -330,14 +330,14 @@ public class NeuronWriter extends ANeuroMLBaseWriter
                 {
 
                     Cell cell = Utils.getCellFromComponent(popComp);
-                    
+
                     IntracellularProperties ip = convertCellWithMorphology(popComp);
                     NamingHelper nh = new NamingHelper(cell);
-                    
+
                     String cellName = popComp.getID();
                     String fileName = cellName + ".hoc";
-                    
-                    
+
+
                     for (Species species: ip.getSpecies()) {
 
                         float internal = NRNUtils.convertToNeuronUnits(Utils.getMagnitudeInSI(species.getInitialConcentration()), "concentration");
@@ -829,7 +829,7 @@ public class NeuronWriter extends ANeuroMLBaseWriter
                     {
                         int preCellId = -1;
                         int postCellId = -1;
-                        
+
                         if(ec.getComponentType().getName().equals(NeuroMLElements.CONTINUOUS_CONNECTION))
                         {
                             preCellId = Integer.parseInt(ec.getStringValue("preCell"));
@@ -1408,9 +1408,9 @@ public class NeuronWriter extends ANeuroMLBaseWriter
         }
         return modFile;
     }
-    
+
     public IntracellularProperties convertCellWithMorphology(Component cellComponent) throws LEMSException, NeuroMLException {
-        
+
         Cell cell = Utils.getCellFromComponent(cellComponent);
         NamingHelper nh = new NamingHelper(cell);
         compIdsVsCells.put(cellComponent.getID(), cell);
@@ -1482,7 +1482,7 @@ public class NeuronWriter extends ANeuroMLBaseWriter
         {
             throw new ContentError("Error writing to file: " + cellFile.getAbsolutePath(), ex);
         }
-        
+
         return ip;
     }
 
@@ -2623,7 +2623,7 @@ public class NeuronWriter extends ANeuroMLBaseWriter
                 }
                 else
                 {
-                    ratesMethod.append(prefix + NRNUtils.getStateVarName(td.getStateVariable().getName()) + " = -1 * " + rateName + "\n");
+                    ratesMethod.append(prefix + NRNUtils.getStateVarName(td.getStateVariable().getName()) + " = -1 * (" + rateNameVsRateExpr.get(rateName) + ")\n");
                 }
 
             }
@@ -2692,7 +2692,7 @@ public class NeuronWriter extends ANeuroMLBaseWriter
                     }
                     else
                     {
-                        ratesMethod.append(prefix + NRNUtils.getStateVarName(td.getStateVariable().getName()) + " = -1 * " + rateName + "\n");
+                        ratesMethod.append(prefix + NRNUtils.getStateVarName(td.getStateVariable().getName()) + " = -1 * (" + rateNameVsRateExpr.get(rateName) + ")\n");
                     }
                 }
             }
@@ -2990,7 +2990,7 @@ public class NeuronWriter extends ANeuroMLBaseWriter
         //lemsFiles.add(new File("../NeuroML2/LEMSexamples/LEMS_NML2_Ex5_DetCell.xml"));
         //lemsFiles.add(new File("../NeuroML2/LEMSexamples/LEMS_NML2_Ex20a_AnalogSynapsesHH.xml"));
         //lemsFiles.add(new File("../NeuroML2/LEMSexamples/LEMS_NML2_Ex20_AnalogSynapses.xml"));
-        
+
         lemsFiles.add(new File("../neuroConstruct/osb/cerebral_cortex/networks/ACnet2/neuroConstruct/generatedNeuroML2/LEMS_StimuliTest.xml"));
         lemsFiles.add(new File("../NeuroML2/LEMSexamples/LEMS_NML2_Ex5_DetCell.xml"));
         lemsFiles.add(new File("../neuroConstruct/osb/cerebellum/cerebellar_granule_cell/GranuleCell/neuroConstruct/generatedNeuroML2/LEMS_GranuleCell.xml"));


### PR DESCRIPTION
using `derivimplict` instead of `cnexp` for _Ca_ dependent mechanisms. See https://github.com/NeuroML/org.neuroml.export/issues/53
