### PR TITLE
fix(GraphWriter): replace hyphens with underscores in simulation ID

### DIFF
--- a/src/main/java/org/neuroml/export/graph/GraphWriter.java
+++ b/src/main/java/org/neuroml/export/graph/GraphWriter.java
@@ -117,7 +117,7 @@ public class GraphWriter extends ANeuroMLBaseWriter
 
 				addComment(main, "GraphViz compliant export for:" + tgtNet.summary() + "\n");
 
-				main.append("digraph " + simCpt.getID() + " {\n");
+				main.append("digraph " + simCpt.getID().replaceAll("-", "_") + " {\n");
 				main.append("fontsize=10;\n\n");
 				if(rankdirLR) main.append("rankdir=\"LR\"\n");
 


### PR DESCRIPTION
The id specified to graph or digraph in Dot cannot contain hyphens[1],
so we replace them with underscores.
[1] https://graphviz.gitlab.io/doc/info/lang.html

Fixes https://github.com/NeuroML/org.neuroml.export/issues/68