### PR TITLE
feat(NeuronWriter): do not print env info on successful execution

### DIFF
--- a/src/main/java/org/neuroml/export/neuron/NeuronWriter.java
+++ b/src/main/java/org/neuroml/export/neuron/NeuronWriter.java
@@ -200,7 +200,6 @@ public class NeuronWriter extends ANeuroMLBaseWriter
                 procOutputError.start();
 
                 E.info("Have successfully executed command: " + commandToExecute);
-                E.info("with: " + Utils.sysEnvInfo("  "));
 
                 try
                 {
@@ -217,7 +216,8 @@ public class NeuronWriter extends ANeuroMLBaseWriter
                 }
                 catch(InterruptedException e)
                 {
-                    E.info("Problem executing Neuron " + e);
+                    E.error("Problem executing Neuron " + e);
+                    E.error("with: " + Utils.sysEnvInfo("  "));
                 }
             }
         }


### PR DESCRIPTION
We only want this information to debug errors when execution fails. In
normal usage, this pollutes the jnml output too much.